### PR TITLE
remove 's' from progress worded output (etah already contains the right plurals)

### DIFF
--- a/teambit.toolbox/network/progress-bar-file-downloader/progress-bar-file-downloader.ts
+++ b/teambit.toolbox/network/progress-bar-file-downloader/progress-bar-file-downloader.ts
@@ -26,7 +26,7 @@ export async function download(url: string, destination: string, opts: DownloadO
     hideCursor: true,
     stopOnComplete: true,
     clearOnComplete: true,
-    format: '[{bar}] {percentage}% | ETA: {etah}s | Speed: {speed}',
+    format: '[{bar}] {percentage}% | ETA: {etah} | Speed: {speed}',
   });
   const finalOpts = Object.assign({}, defaults, opts);
   const exists = await fs.pathExists(destination);


### PR DESCRIPTION
As in the title