### PR TITLE
Reverse array in version list to see latest versions

### DIFF
--- a/teambit.bvm/commands/list/list.ts
+++ b/teambit.bvm/commands/list/list.ts
@@ -47,7 +47,7 @@ export class ListCmd implements CommandModule {
     ];
 
     // @ts-ignore
-    const table = new Table(headers, list.entries, options);
+    const table = new Table(headers, list.entries.reverse(), options);
     return table.render();
   }
 
@@ -73,7 +73,7 @@ export class ListCmd implements CommandModule {
   }
   async handler(args) {
     if (args.remote) {
-      const list = await listRemote({ 'limit': args['limit'] });
+      const list = await listRemote({ limit: args['limit'] });
       console.log(ListCmd.toTable(list));
       return;
     }


### PR DESCRIPTION
Today we can't see the latest versions, if we reverse the printed array we'll be able to see the latest versions.
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/35892475/163808082-9421fcb4-401f-4651-80a3-dd15f6239b3a.png">
