### PR TITLE
fix: don't install Node.js on a system that uses MUSL libc

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@babel/runtime': 7.12.18
       '@pnpm/fetch': '4'
       '@pnpm/logger': ^4.0.0
-      '@pnpm/node.fetcher': 0.1.0
+      '@pnpm/node.fetcher': 0.1.1
       '@pnpm/os.env.path-extender': 0.2.4
       '@teambit/toolbox.network.agent': 0.0.245
       '@teambit/toolbox.time.time-format': 0.0.443
@@ -55,7 +55,7 @@ importers:
     dependencies:
       '@pnpm/fetch': registry.npmjs.org/@pnpm/fetch/4.2.7_@pnpm+logger@4.0.0
       '@pnpm/logger': registry.npmjs.org/@pnpm/logger/4.0.0
-      '@pnpm/node.fetcher': registry.npmjs.org/@pnpm/node.fetcher/0.1.0_@pnpm+logger@4.0.0
+      '@pnpm/node.fetcher': registry.npmjs.org/@pnpm/node.fetcher/0.1.1_@pnpm+logger@4.0.0
       '@pnpm/os.env.path-extender': registry.npmjs.org/@pnpm/os.env.path-extender/0.2.4
       '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245
       '@teambit/toolbox.time.time-format': registry.npmjs.org/@teambit/toolbox.time.time-format/0.0.443
@@ -388,18 +388,20 @@ packages:
       - supports-color
     dev: false
 
-  registry.npmjs.org/@pnpm/node.fetcher/0.1.0_@pnpm+logger@4.0.0:
-    resolution: {integrity: sha512-gVhUhw0hEIPDNj67WadnlR3N6QQm1XDlntaUjkDlACICuBUOF9mrjOg0goyY2Xmey30umZiyn04tH7VmrykYmw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@pnpm/node.fetcher/-/node.fetcher-0.1.0.tgz}
-    id: registry.npmjs.org/@pnpm/node.fetcher/0.1.0
+  registry.npmjs.org/@pnpm/node.fetcher/0.1.1_@pnpm+logger@4.0.0:
+    resolution: {integrity: sha512-jTIp2VSeBlfOSvmp407NxXextQwM2omhhnGDcMX4IPtPULDPEsXInncGxgFsjiqhH9Ld8k1+g6L53fBG2tc7PA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@pnpm/node.fetcher/-/node.fetcher-0.1.1.tgz}
+    id: registry.npmjs.org/@pnpm/node.fetcher/0.1.1
     name: '@pnpm/node.fetcher'
-    version: 0.1.0
+    version: 0.1.1
     engines: {node: '>=12.17'}
     dependencies:
+      '@pnpm/error': registry.npmjs.org/@pnpm/error/2.1.0
       '@pnpm/fetcher-base': registry.npmjs.org/@pnpm/fetcher-base/11.2.0
       '@pnpm/fetching-types': registry.npmjs.org/@pnpm/fetching-types/2.2.1
       '@pnpm/package-store': registry.npmjs.org/@pnpm/package-store/12.2.0_@pnpm+logger@4.0.0
       '@pnpm/tarball-fetcher': registry.npmjs.org/@pnpm/tarball-fetcher/9.3.19_@pnpm+logger@4.0.0
       adm-zip: registry.npmjs.org/adm-zip/0.5.9
+      detect-libc: registry.npmjs.org/detect-libc/2.0.1
       rename-overwrite: registry.npmjs.org/rename-overwrite/4.0.2
       tempy: registry.npmjs.org/tempy/1.0.1
     transitivePeerDependencies:
@@ -1479,6 +1481,13 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz}
     name: detect-indent
     version: 6.1.0
+    engines: {node: '>=8'}
+    dev: false
+
+  registry.npmjs.org/detect-libc/2.0.1:
+    resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz}
+    name: detect-libc
+    version: 2.0.1
     engines: {node: '>=8'}
     dev: false
 

--- a/teambit.bvm/commands/install/install.ts
+++ b/teambit.bvm/commands/install/install.ts
@@ -63,12 +63,12 @@ export class InstallCmd implements CommandModule {
       useSystemNode: args.useSystemNode,
     }
     const installStartTime = Date.now();
-    const {versionPath, installedVersion, pathExtenderReport, warning} = await installVersion(args.bitVersion, opts);
+    const {versionPath, installedVersion, pathExtenderReport, warnings} = await installVersion(args.bitVersion, opts);
     const installEndTime = Date.now();
     const installTimeDiff = timeFormat(installEndTime - installStartTime);
     console.log(`version ${chalk.green(installedVersion)} installed on ${chalk.green(versionPath)} in ${chalk.cyan(installTimeDiff)}`);
-    if (warning) {
-      console.log(chalk.yellowBright(warning));
+    if (warnings && warnings.length) {
+      console.log(chalk.yellowBright(warnings.join('\n')));
     }
     if (!pathExtenderReport) return; 
     const output = renderPathExtenderReport(pathExtenderReport);

--- a/teambit.bvm/commands/install/install.ts
+++ b/teambit.bvm/commands/install/install.ts
@@ -63,10 +63,13 @@ export class InstallCmd implements CommandModule {
       useSystemNode: args.useSystemNode,
     }
     const installStartTime = Date.now();
-    const {versionPath, installedVersion, pathExtenderReport} = await installVersion(args.bitVersion, opts);
+    const {versionPath, installedVersion, pathExtenderReport, warning} = await installVersion(args.bitVersion, opts);
     const installEndTime = Date.now();
     const installTimeDiff = timeFormat(installEndTime - installStartTime);
     console.log(`version ${chalk.green(installedVersion)} installed on ${chalk.green(versionPath)} in ${chalk.cyan(installTimeDiff)}`);
+    if (warning) {
+      console.log(chalk.yellowBright(warning));
+    }
     if (!pathExtenderReport) return; 
     const output = renderPathExtenderReport(pathExtenderReport);
     if (output) {

--- a/teambit.bvm/install/install.ts
+++ b/teambit.bvm/install/install.ts
@@ -26,7 +26,7 @@ export type InstallResults = {
   previousCurrentVersion?: string
   versionPath: string,
   pathExtenderReport?: PathExtenderReport,
-  warning?: string,
+  warnings?: string[],
 }
 
 const defaultOpts = {
@@ -58,7 +58,7 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
         replacedCurrent: replacedCurrentResult.replaced,
         previousCurrentVersion: replacedCurrentResult.previousCurrentVersion,
         pathExtenderReport: replacedCurrentResult.pathExtenderReport,
-        warning: replacedCurrentResult.warning,
+        warnings: replacedCurrentResult.warnings,
         versionPath: versionDir
       }
     }
@@ -105,7 +105,7 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
     replacedCurrent: replacedCurrentResult.replaced,
     previousCurrentVersion: replacedCurrentResult.previousCurrentVersion,
     pathExtenderReport: replacedCurrentResult.pathExtenderReport,
-    warning: replacedCurrentResult.warning,
+    warnings: replacedCurrentResult.warnings,
     versionPath: versionDir
   }
 }
@@ -170,14 +170,14 @@ type ReplaceCurrentResult = {
   replaced: boolean,
   pathExtenderReport?: PathExtenderReport,
   previousCurrentVersion?: string,
-  warning?: string,
+  warnings?: string[],
 }
 
 async function replaceCurrentIfNeeded(forceReplace: boolean, version: string, opts: { addToPathIfMissing?: boolean, useSystemNode?: boolean }): Promise<ReplaceCurrentResult> {
   const config = getConfig();
   const currentLink = config.getDefaultLinkVersion();
   if (forceReplace || !currentLink){
-    const {previousLinkVersion, pathExtenderReport, warning} = await linkOne(config.getDefaultLinkName(), version, {
+    const {previousLinkVersion, pathExtenderReport, warnings} = await linkOne(config.getDefaultLinkName(), version, {
       addToConfig: true,
       addToPathIfMissing: opts.addToPathIfMissing,
       useSystemNode: opts.useSystemNode,
@@ -186,7 +186,7 @@ async function replaceCurrentIfNeeded(forceReplace: boolean, version: string, op
       replaced: true,
       previousCurrentVersion: previousLinkVersion,
       pathExtenderReport,
-      warning,
+      warnings,
     };
   }
   return {

--- a/teambit.bvm/install/install.ts
+++ b/teambit.bvm/install/install.ts
@@ -26,6 +26,7 @@ export type InstallResults = {
   previousCurrentVersion?: string
   versionPath: string,
   pathExtenderReport?: PathExtenderReport,
+  warning?: string,
 }
 
 const defaultOpts = {
@@ -57,6 +58,7 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
         replacedCurrent: replacedCurrentResult.replaced,
         previousCurrentVersion: replacedCurrentResult.previousCurrentVersion,
         pathExtenderReport: replacedCurrentResult.pathExtenderReport,
+        warning: replacedCurrentResult.warning,
         versionPath: versionDir
       }
     }
@@ -103,6 +105,7 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
     replacedCurrent: replacedCurrentResult.replaced,
     previousCurrentVersion: replacedCurrentResult.previousCurrentVersion,
     pathExtenderReport: replacedCurrentResult.pathExtenderReport,
+    warning: replacedCurrentResult.warning,
     versionPath: versionDir
   }
 }
@@ -166,14 +169,15 @@ async function moveWithLoader(src: string, target: string, opts: MoveOptions): P
 type ReplaceCurrentResult = {
   replaced: boolean,
   pathExtenderReport?: PathExtenderReport,
-  previousCurrentVersion?: string
+  previousCurrentVersion?: string,
+  warning?: string,
 }
 
 async function replaceCurrentIfNeeded(forceReplace: boolean, version: string, opts: { addToPathIfMissing?: boolean, useSystemNode?: boolean }): Promise<ReplaceCurrentResult> {
   const config = getConfig();
   const currentLink = config.getDefaultLinkVersion();
   if (forceReplace || !currentLink){
-    const {previousLinkVersion, pathExtenderReport} = await linkOne(config.getDefaultLinkName(), version, {
+    const {previousLinkVersion, pathExtenderReport, warning} = await linkOne(config.getDefaultLinkName(), version, {
       addToConfig: true,
       addToPathIfMissing: opts.addToPathIfMissing,
       useSystemNode: opts.useSystemNode,
@@ -182,6 +186,7 @@ async function replaceCurrentIfNeeded(forceReplace: boolean, version: string, op
       replaced: true,
       previousCurrentVersion: previousLinkVersion,
       pathExtenderReport,
+      warning,
     };
   }
   return {

--- a/teambit.bvm/link/link.ts
+++ b/teambit.bvm/link/link.ts
@@ -22,7 +22,7 @@ export type LinkResult = {
   previousLinkVersion?: string,
   generatedLink: GeneratedLink
   pathExtenderReport?: PathExtenderReport,
-  warning?: string,
+  warnings?: string[],
 }
 
 export { PathExtenderReport, ConfigReport, ConfigFileChangeType }
@@ -84,7 +84,7 @@ export async function linkOne(linkName: string, version: string | undefined, opt
   }
   let nodeExecPath: string;
   const wantedNodeVersion = config.getWantedNodeVersion(versionDir);
-  let warning: string
+  const warnings: string[] = []
   if (!opts.useSystemNode) {
     if (wantedNodeVersion) {
       const node = config.getSpecificNodeVersionDir(wantedNodeVersion);
@@ -94,7 +94,7 @@ export async function linkOne(linkName: string, version: string | undefined, opt
       nodeExecPath = path.join(node.versionDir, process.platform === 'win32' ? 'node.exe' : 'bin/node');
     }
   } else if (semver.lt(process.version, wantedNodeVersion)) {
-    warning = `The system Node.js is ${process.version} while Bit CLI requires at least Node.js ${wantedNodeVersion}!`
+    warnings.push(`The system Node.js is ${process.version} while Bit CLI requires at least Node.js ${wantedNodeVersion}!`)
   }
   const pkg = {
     bin: {
@@ -137,7 +137,7 @@ export async function linkOne(linkName: string, version: string | undefined, opt
     version: concreteVersion,
     generatedLink,
     pathExtenderReport,
-    warning,
+    warnings,
   }
 }
 

--- a/teambit.bvm/link/link.ts
+++ b/teambit.bvm/link/link.ts
@@ -7,6 +7,7 @@ import binLinks from 'bin-links';
 import { BvmError } from '@teambit/bvm.error';
 import os from 'os';
 import chalk from 'chalk';
+import semver from 'semver';
 
 const IS_WINDOWS = os.platform() === 'win32';
 const DOCS_BASE_URL = 'https://bit.dev/docs';
@@ -21,6 +22,7 @@ export type LinkResult = {
   previousLinkVersion?: string,
   generatedLink: GeneratedLink
   pathExtenderReport?: PathExtenderReport,
+  warning?: string,
 }
 
 export { PathExtenderReport, ConfigReport, ConfigFileChangeType }
@@ -81,8 +83,9 @@ export async function linkOne(linkName: string, version: string | undefined, opt
     throw new BvmError(`version ${concreteVersion} is not installed`);
   }
   let nodeExecPath: string;
+  const wantedNodeVersion = config.getWantedNodeVersion(versionDir);
+  let warning: string
   if (!opts.useSystemNode) {
-    const wantedNodeVersion = config.getWantedNodeVersion(versionDir);
     if (wantedNodeVersion) {
       const node = config.getSpecificNodeVersionDir(wantedNodeVersion);
       if (!node.exists) {
@@ -90,6 +93,8 @@ export async function linkOne(linkName: string, version: string | undefined, opt
       }
       nodeExecPath = path.join(node.versionDir, process.platform === 'win32' ? 'node.exe' : 'bin/node');
     }
+  } else if (semver.lt(process.version, wantedNodeVersion)) {
+    warning = `The system Node.js is ${process.version} while Bit CLI requires at least Node.js ${wantedNodeVersion}!`
   }
   const pkg = {
     bin: {
@@ -132,6 +137,7 @@ export async function linkOne(linkName: string, version: string | undefined, opt
     version: concreteVersion,
     generatedLink,
     pathExtenderReport,
+    warning,
   }
 }
 

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -37,7 +37,7 @@
       "dependencies": {
         "@pnpm/fetch": "4",
         "@pnpm/logger": "4.0.0",
-        "@pnpm/node.fetcher": "0.1.0",
+        "@pnpm/node.fetcher": "0.1.1",
         "@pnpm/os.env.path-extender": "0.2.4",
         "@teambit/toolbox.network.agent": "0.0.245",
         "@teambit/toolbox.time.time-format": "0.0.443",


### PR DESCRIPTION
Changes:

* Node.js doesn't ship artifacts for systems using the MUSL C standard library, so on those systems we use the system installed Node.js
* if the system installed Node.js is older than the one required by bit CLI, and warning is printed