### PR TITLE
feat: download bit from new location when `release-type` is set to `nightly`

### DIFF
--- a/teambit.bvm/config/config.ts
+++ b/teambit.bvm/config/config.ts
@@ -22,6 +22,7 @@ const CONFIG_KEY_NAME = 'global';
 
 
 export const CFG_BVM_DIR = 'BVM_DIR';
+export const CFG_RELEASE_TYPE = 'RELEASE_TYPE';
 export const CFG_PROXY = 'proxy';
 export const CFG_HTTPS_PROXY = 'https_proxy';
 export const CFG_PROXY_CA = 'proxy.ca';
@@ -266,6 +267,10 @@ export class Config {
       return acc;
     }, {});
     return res;
+  }
+
+  getReleaseType() {
+    return this.get(CFG_RELEASE_TYPE);
   }
 
   setLink(linkName: string, value: string): string {

--- a/teambit.bvm/fetch/fetch.ts
+++ b/teambit.bvm/fetch/fetch.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { listRemote } from '@teambit/bvm.list';
+import { listRemote, ReleaseType } from '@teambit/bvm.list';
 import { Config } from '@teambit/bvm.config';
 import { download as fileDownload } from '@teambit/toolbox.network.progress-bar-file-downloader';
 import ora from 'ora';
@@ -36,6 +36,11 @@ export async function fetch(version: string, opts: FetchOpts): Promise<FsTarVers
     resolvedVersion = remoteVersionList.latest();
   } else {
     resolvedVersion = remoteVersionList.find(version);
+    if (!resolvedVersion) {
+      // If the given version is not found, try to fetch it from the old location
+      const oldVersions = await listRemote({ releaseType: ReleaseType.NIGHTLY_FROM_OLD_LOCATION });
+      resolvedVersion = oldVersions.find(version);
+    }
   }
 
   if (!resolvedVersion) {

--- a/teambit.bvm/list/gcp/gcp-list.spec.ts
+++ b/teambit.bvm/list/gcp/gcp-list.spec.ts
@@ -1,0 +1,86 @@
+import { GcpList, ReleaseType, Release } from './gcp-list';
+import fetch from 'node-fetch';
+
+jest.mock('node-fetch', () => jest.fn());
+
+describe('GcpList', () => {
+  it('should return the correct URL on Windows', async () => {
+    mockFetch([
+      {
+        version: '1.0.0',
+        date: '2020-01-01',
+        nightly: true,
+      },
+    ]);
+    const gcpList = GcpList.create(ReleaseType.nightly, 'Windows_NT', 'x64');
+    const list = await gcpList.list();
+    expect(list.entries[0].url).toBe('https://bvm.bit.dev/bit/versions/1.0.0/bit-1.0.0-win-x64.tar.gz');
+  });
+  it('should return the correct URL on Linux', async () => {
+    mockFetch([
+      {
+        version: '1.0.0',
+        date: '2020-01-01',
+        nightly: true,
+      },
+    ]);
+    const gcpList = GcpList.create(ReleaseType.nightly, 'Linux', 'x64');
+    const list = await gcpList.list();
+    expect(list.entries[0].url).toBe('https://bvm.bit.dev/bit/versions/1.0.0/bit-1.0.0-linux-x64.tar.gz');
+  });
+  it('should return the correct URL on macOS', async () => {
+    mockFetch([
+      {
+        version: '1.0.0',
+        date: '2020-01-01',
+        nightly: true,
+      },
+    ]);
+    const gcpList = GcpList.create(ReleaseType.nightly, 'Darwin', 'x64');
+    const list = await gcpList.list();
+    expect(list.entries[0].url).toBe('https://bvm.bit.dev/bit/versions/1.0.0/bit-1.0.0-darwin-x64.tar.gz');
+  });
+  it('should return the correct URL on macOS with arm64 CPU', async () => {
+    mockFetch([
+      {
+        version: '1.0.0',
+        date: '2020-01-01',
+        nightly: true,
+      },
+    ]);
+    const gcpList = GcpList.create(ReleaseType.nightly, 'Darwin', 'arm64');
+    const list = await gcpList.list();
+    expect(list.entries[0].url).toBe('https://bvm.bit.dev/bit/versions/1.0.0/bit-1.0.0-darwin-arm64.tar.gz');
+  });
+  it('should return only stable releases', async () => {
+    mockFetch([
+      {
+        version: '1.0.0',
+        date: '2020-01-01',
+        stable: true,
+        nightly: true,
+      },
+      {
+        version: '2.0.0',
+        date: '2020-01-01',
+        nightly: true,
+      },
+      {
+        version: '3.0.0',
+        date: '2020-01-01',
+        stable: true,
+      },
+    ]);
+    const gcpList = GcpList.create(ReleaseType.STABLE, 'Windows_NT', 'x64');
+    const list = await gcpList.list();
+    expect(list.entries.length).toBe(2);
+    expect(list.entries[0].version).toBe('1.0.0')
+    expect(list.entries[1].version).toBe('3.0.0')
+  });
+});
+
+function mockFetch(releases: Release[]) {
+  fetch['mockReturnValue'](Promise.resolve({
+    json: () => Promise.resolve(releases),
+  }));
+}

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -1,9 +1,11 @@
 import { GcpStorage } from '@teambit/gcp.storage';
+import { getAgent } from '@teambit/toolbox.network.agent';
 import fetch from 'node-fetch';
 import { GcpVersion } from './gcp-version';
 import { RemoteVersionList } from '../version-list';
 import { RemoteVersion } from '../version';
 
+const BIT_INDEX_JSON = 'https://bvm.bit.dev/bit/index.json';
 const bucketName = 'bvm.bit.dev';
 const prefix = 'versions';
 
@@ -20,11 +22,17 @@ export type Release = {
 } & Partial<Record<ReleaseType, true>>
 
 export class GcpList {
-  constructor(private gcpStorage: GcpStorage, private osType = 'Darwin', private arch = 'x64', private releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION) { }
+  constructor(
+    private gcpStorage: GcpStorage,
+    private proxyConfig = {},
+    private osType = 'Darwin',
+    private arch = 'x64',
+    private releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION,
+  ) { }
 
   async list(): Promise<RemoteVersionList> {
     if (this.releaseType !== ReleaseType.NIGHTLY_FROM_OLD_LOCATION) {
-      const releases = await fetchReleasesList();
+      const releases = await this._fetchReleasesList();
       const remoteVersions = releases
         .filter((release) => release[this.releaseType] === true)
         .map((release) => this._createRemoteVersion(release));
@@ -36,6 +44,13 @@ export class GcpList {
       return gcpVersion.toRemoteVersion();
     });
     return new RemoteVersionList(remoteVersions);
+  }
+
+  async _fetchReleasesList(): Promise<Release[]> {
+    const response = await fetch(BIT_INDEX_JSON, {
+      agent: getAgent(BIT_INDEX_JSON, this.proxyConfig),
+    });
+    return await response.json() as Release[];
   }
 
   _createRemoteVersion(release: Release): RemoteVersion {
@@ -55,13 +70,8 @@ export class GcpList {
 
   static create(releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION, osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
     const gcpStorage = GcpStorage.create(bucketName, proxyConfig);
-    return new GcpList(gcpStorage, osType, arch, releaseType);
+    return new GcpList(gcpStorage, proxyConfig, osType, arch, releaseType);
   }
-}
-
-async function fetchReleasesList(): Promise<Release[]> {
-  const response = await fetch('https://bvm.bit.dev/bit/index.json');
-  return await response.json() as Release[];
 }
 
 function getVersionFromFileName(fileName: string) {

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -12,7 +12,7 @@ const prefix = 'versions';
 export enum ReleaseType {
   NIGHTLY_FROM_OLD_LOCATION = 'nightly-from-old-location',
   DEV = 'dev',
-  nightly = 'nightly',
+  NIGHTLY = 'nightly',
   STABLE = 'stable',
 }
 
@@ -27,7 +27,7 @@ export class GcpList {
     private proxyConfig = {},
     private osType = 'Darwin',
     private arch = 'x64',
-    private releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION,
+    private releaseType: ReleaseType = ReleaseType.NIGHTLY,
   ) { }
 
   async list(): Promise<RemoteVersionList> {
@@ -68,7 +68,7 @@ export class GcpList {
     return this.gcpStorage.getFiles({ prefix: filesPrefix });
   }
 
-  static create(releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION, osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
+  static create(releaseType: ReleaseType = ReleaseType.NIGHTLY, osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
     const gcpStorage = GcpStorage.create(bucketName, proxyConfig);
     return new GcpList(gcpStorage, proxyConfig, osType, arch, releaseType);
   }

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -24,7 +24,7 @@ export class GcpList {
 
   async list(): Promise<RemoteVersionList> {
     if (this.releaseType !== ReleaseType.NIGHTLY_FROM_OLD_LOCATION) {
-      const releases = await (await fetch('https://bvm.bit.dev/bit/index.json')).json() as Release[];
+      const releases = await fetchReleasesList();
       const remoteVersions = releases
         .filter((release) => release[this.releaseType] === true)
         .map((release) => this._createRemoteVersion(release));
@@ -56,6 +56,11 @@ export class GcpList {
     const gcpStorage = GcpStorage.create(bucketName, proxyConfig);
     return new GcpList(gcpStorage, osType, arch, releaseType);
   }
+}
+
+async function fetchReleasesList(): Promise<Release[]> {
+  const response = await fetch('https://bvm.bit.dev/bit/index.json');
+  return await response.json() as Release[];
 }
 
 function getVersionFromFileName(fileName: string) {

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -14,10 +14,10 @@ export enum ReleaseType {
   STABLE = 'stable',
 }
 
-type Release = {
+export type Release = {
   version: string;
   date: string;
-} & Record<ReleaseType, true>
+} & Partial<Record<ReleaseType, true>>
 
 export class GcpList {
   constructor(private gcpStorage: GcpStorage, private osType = 'Darwin', private arch = 'x64', private releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION) { }

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -1,32 +1,58 @@
 import { GcpStorage } from '@teambit/gcp.storage';
+import fetch from 'node-fetch';
 import { GcpVersion } from './gcp-version';
 import { RemoteVersionList } from '../version-list';
 
 const bucketName = 'bvm.bit.dev';
 const prefix = 'versions';
 
+export enum ReleaseType {
+  NIGHTLY_FROM_OLD_LOCATION = 'nightly-from-old-location',
+  DEV = 'dev',
+  nightly = 'nightly',
+  STABLE = 'stable',
+}
+
 export class GcpList {
-  constructor(private gcpStorage: GcpStorage, private osType = 'Darwin', private arch = 'x64', private releaseType = 'dev') { }
+  constructor(private gcpStorage: GcpStorage, private osType = 'Darwin', private arch = 'x64', private releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION) { }
 
   async list(): Promise<RemoteVersionList> {
+    if (this.releaseType !== ReleaseType.NIGHTLY_FROM_OLD_LOCATION) {
+      const releases = await (await fetch('https://bvm.bit.dev/bit/index.json')).json();
+      const remoteVersions = releases
+        .filter((release) => release[this.releaseType] === true)
+        .map((release) => {
+          const gcpVersion = new GcpVersion(release.version, `bit/versions/${release.version}/bit-${release.version}-${this.osType.toLowerCase()}-${this.arch}.tar.gz`, bucketName, '', release.date, {});
+          return gcpVersion.toRemoteVersion();
+        });
+      return new RemoteVersionList(remoteVersions);
+    }
     const files = (await this.rawFiles()).filter(file => file.contentType === 'application/x-tar');
     const remoteVersions = files.map((file) => {
-      const gcpVersion = new GcpVersion(file.name, file.bucket, file.md5Hash, file.timeCreated, file.metadata);
+      const gcpVersion = new GcpVersion(getVersionFromFileName(file.name), file.name, file.bucket, file.md5Hash, file.timeCreated, file.metadata);
       return gcpVersion.toRemoteVersion();
     });
     return new RemoteVersionList(remoteVersions);
   }
 
   async rawFiles() {
-    let filesPrefix = `${prefix}/${this.releaseType}/${this.osType}/`;
+    let filesPrefix = `${prefix}/dev/${this.osType}/`;
     if (this.osType === 'Darwin' && this.arch === 'arm64'){
-      filesPrefix = `${prefix}/${this.releaseType}/${this.osType}-${this.arch}/`;
+      filesPrefix = `${prefix}/dev/${this.osType}-${this.arch}/`;
     }
     return this.gcpStorage.getFiles({ prefix: filesPrefix });
   }
 
-  static create(releaseType = 'dev', osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
+  static create(releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION, osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
     const gcpStorage = GcpStorage.create(bucketName, proxyConfig);
     return new GcpList(gcpStorage, osType, arch, releaseType);
   }
+}
+
+function getVersionFromFileName(fileName: string) {
+  return fileName
+    .split('/')[4]
+    .replace(/\.[^/.]+$/, '')
+    .replace(/\.[^/.]+$/, '')
+    .split('-')[1];
 }

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -39,7 +39,8 @@ export class GcpList {
   }
 
   _createRemoteVersion(release: Release): RemoteVersion {
-    const fileName = `bit/versions/${release.version}/bit-${release.version}-${this.osType.toLowerCase()}-${this.arch}.tar.gz`;
+    const osCode = this.osType === 'Windows_NT' ? 'win' : this.osType.toLowerCase();
+    const fileName = `bit/versions/${release.version}/bit-${release.version}-${osCode}-${this.arch}.tar.gz`;
     const gcpVersion = new GcpVersion(release.version, fileName, bucketName, '', release.date, {});
     return gcpVersion.toRemoteVersion();
   }

--- a/teambit.bvm/list/gcp/gcp-list.ts
+++ b/teambit.bvm/list/gcp/gcp-list.ts
@@ -27,7 +27,7 @@ export class GcpList {
     private proxyConfig = {},
     private osType = 'Darwin',
     private arch = 'x64',
-    private releaseType: ReleaseType = ReleaseType.NIGHTLY,
+    private releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION,
   ) { }
 
   async list(): Promise<RemoteVersionList> {
@@ -68,7 +68,7 @@ export class GcpList {
     return this.gcpStorage.getFiles({ prefix: filesPrefix });
   }
 
-  static create(releaseType: ReleaseType = ReleaseType.NIGHTLY, osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
+  static create(releaseType: ReleaseType = ReleaseType.NIGHTLY_FROM_OLD_LOCATION, osType = 'Darwin', arch = 'x64', proxyConfig?: {}) {
     const gcpStorage = GcpStorage.create(bucketName, proxyConfig);
     return new GcpList(gcpStorage, proxyConfig, osType, arch, releaseType);
   }

--- a/teambit.bvm/list/gcp/gcp-version.spec.ts
+++ b/teambit.bvm/list/gcp/gcp-version.spec.ts
@@ -4,26 +4,26 @@ const versionPath = "versions/dev/Darwin/0.0.315/bit-0.0.315.tar.gz";
 describe("Google Cloud Storage Versions List", () => {
   describe("version", () => {
     it("should return bit version from Class", async () => {
-      const version = new GcpVersion(versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
+      const version = new GcpVersion('0.0.315', versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
       expect(version.version).toBe("0.0.315");
     });
 
     it("should return bit version from Object", async () => {
-      const version = new GcpVersion(versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
+      const version = new GcpVersion('0.0.315', versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
       expect(version.toObject().version).toBe("0.0.315");
     });
   });
 
   describe("download url", () => {
     it("should return download url from Class", async () => {
-      const version = new GcpVersion(versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
+      const version = new GcpVersion('0.0.315', versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
 
       expect(version.url).toBe(
         "https://bvm.bit.dev/versions/dev/Darwin/0.0.315/bit-0.0.315.tar.gz"
       );
     });
     it("should return download url from Object", async () => {
-      const version = new GcpVersion(versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
+      const version = new GcpVersion('0.0.315', versionPath, "bvm.bit.dev", '0DebjGCNrSyBz/zpSV', '2022-01-05T22:50:52.883Z', {}, "https");
 
       expect(version.toObject().url).toBe(
         "https://bvm.bit.dev/versions/dev/Darwin/0.0.315/bit-0.0.315.tar.gz"

--- a/teambit.bvm/list/gcp/gcp-version.ts
+++ b/teambit.bvm/list/gcp/gcp-version.ts
@@ -2,6 +2,7 @@ import { RemoteVersion } from '../version';
 
 export class GcpVersion {
   constructor(
+    public version: string,
     private fileName: string,
     private host: string,
     private md5hash: string,
@@ -9,14 +10,6 @@ export class GcpVersion {
     private metadata: { [key: string]: string },
     private protocol = 'https'
   ) { }
-
-  get version() {
-    return this.fileName
-      .split('/')[4]
-      .replace(/\.[^/.]+$/, '')
-      .replace(/\.[^/.]+$/, '')
-      .split('-')[1];
-  }
 
   get url() {
     return `${this.protocol}://${this.host}/${this.fileName}`;

--- a/teambit.bvm/list/gcp/index.ts
+++ b/teambit.bvm/list/gcp/index.ts
@@ -1,2 +1,2 @@
-export {GcpList} from './gcp-list';
+export {GcpList, ReleaseType} from './gcp-list';
 export {GcpVersion} from './gcp-version';

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { GcpList, ReleaseType } from './gcp';
+import { GcpList } from './gcp';
 import { Config } from '@teambit/bvm.config';
 import semver from 'semver';
 import fs from 'fs-extra';

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -16,7 +16,7 @@ export type ListOptions = {
 const config = Config.load();
 
 export async function listRemote(options?: ListOptions): Promise<RemoteVersionList> {
-  const releaseType = options?.releaseType ?? config.get('release-type');
+  const releaseType = options?.releaseType ?? config.getReleaseType();
   const gcpList = GcpList.create(releaseType, os.type(), process.arch, {
     ...config.networkConfig(),
     ...config.proxyConfig(),

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -1,24 +1,20 @@
 import os from 'os';
-import { GcpList } from './gcp';
+import { GcpList, ReleaseType } from './gcp';
 import { Config } from '@teambit/bvm.config';
 import semver from 'semver';
 import fs from 'fs-extra';
 import { LocalVersionList, RemoteVersionList } from './version-list';
 import { LocalVersion } from './version';
 
-// export enum ReleaseType {
-//   STABLE = 'stable',
-// }
-
 export type ListOptions = {
   limit?: number;
-  // 'release-type'?: ReleaseType;
 };
 
 const config = Config.load();
 
 export async function listRemote(options?: ListOptions): Promise<RemoteVersionList> {
-  const gcpList = GcpList.create('dev', os.type(), process.arch, {
+  const releaseType = config.get('release-type');
+  const gcpList = GcpList.create(releaseType, os.type(), process.arch, {
     ...config.networkConfig(),
     ...config.proxyConfig(),
   });

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -1,19 +1,22 @@
 import os from 'os';
-import { GcpList } from './gcp';
+import { GcpList, ReleaseType } from './gcp';
 import { Config } from '@teambit/bvm.config';
 import semver from 'semver';
 import fs from 'fs-extra';
 import { LocalVersionList, RemoteVersionList } from './version-list';
 import { LocalVersion } from './version';
 
+export { ReleaseType };
+
 export type ListOptions = {
   limit?: number;
+  releaseType?: ReleaseType;
 };
 
 const config = Config.load();
 
 export async function listRemote(options?: ListOptions): Promise<RemoteVersionList> {
-  const releaseType = config.get('release-type');
+  const releaseType = options?.releaseType ?? config.get('release-type');
   const gcpList = GcpList.create(releaseType, os.type(), process.arch, {
     ...config.networkConfig(),
     ...config.proxyConfig(),


### PR DESCRIPTION
A `release-type` may be set to change what version of Bit to install (e.g., `bit config set release-type dev`)

`nightly` will be installed from the new location (from `//bvm.bit.dev/bit/versions/`).

To install nightly from the old location, `release-type` may be set to `nightly-from-old-location`. This will be the default for now.

If a bit version is installed using exact version (e.g., `bvm install 0.0.415`) and the version is not found at the new location, bvm tries to install it from the old location.