### PR TITLE
Add nightly to version output

### DIFF
--- a/teambit.bvm/commands/version/version.ts
+++ b/teambit.bvm/commands/version/version.ts
@@ -176,24 +176,27 @@ function getNewerBitAvailableOutput(
   if (!latestInstalledVersion && !latestRemoteStableVersion && !latestRemoteNightlyVersion) {
     return undefined;
   }
+
+  const moreRecentLocalVersionOutput = latestInstalledVersion && (semver.gt(latestInstalledVersion, currentVersion)) 
+    ? `\nNOTE: you have a more recent version of bit (${latestInstalledVersion}) installed on your machine - run ${chalk.cyan(`bvm use ${latestInstalledVersion}`)} to use your latest installed version`
+    : undefined;
+
   function newVersionAvailableText(versionToCheck?: Version){
     if (!versionToCheck) return undefined;
+    const { version, releaseType } = versionToCheck;
 
     const commandToRun = versionToCheck.releaseType === ReleaseType.STABLE ?
-      `bvm install ${versionToCheck.version}`
+      `bvm install ${version}`
       : "bvm upgrade"
     
-    if (
-      semver.gt(latestInstalledVersion || "0.0.0", currentVersion || "0.0.0") ||
-      (versionToCheck.version && semver.gt(versionToCheck.version, currentVersion || "0.0.0"))
-    )
+    if ((version && semver.gt(version, currentVersion || "0.0.0")))
     {
-      return `new ${versionToCheck.releaseType?.toString() ?? ""} version (${versionToCheck.version}) of ${chalk.cyan("bit")} `+
-           `is available, upgrade your ${chalk.cyan("bit")} by running "${chalk.cyan(commandToRun)}"\n`;
-    }
+      return `${chalk.greenBright("newer")} ${releaseType?.toString() ?? ""} version (${version}) of ${chalk.cyan("bit")} `+
+           `is available, upgrade ${chalk.cyan("bit")} to the latest version by running "${chalk.cyan(commandToRun)}"\n`;
+    }      
   }
-  latestRemoteStableVersion = undefined;
-  const output = [newVersionAvailableText(latestRemoteStableVersion), newVersionAvailableText(latestRemoteNightlyVersion)].join("");
+
+  const output = [newVersionAvailableText(latestRemoteStableVersion), newVersionAvailableText(latestRemoteNightlyVersion), moreRecentLocalVersionOutput].join("");
     
   return output;
 }

--- a/teambit.bvm/commands/version/version.ts
+++ b/teambit.bvm/commands/version/version.ts
@@ -144,10 +144,8 @@ function formatOutput(versions: VersionsResult): string {
     versions.latestBvmRemoteVersion
   );
   const newerBitOutput = getNewerBitAvailableOutput(
-    currentVersion?.version,
-    latestInstalledVersion?.version,
-    latestRemoteStableVersion,
-    latestRemoteNightlyVersion
+    versions.localBitVersions,
+    versions.remoteBitVersions
   );
 
   const outputs = [
@@ -165,11 +163,12 @@ function formatOutput(versions: VersionsResult): string {
 }
 
 function getNewerBitAvailableOutput(
-  currentVersion?: string,
-  latestInstalledVersion?: string,
-  latestRemoteStableVersion?: Version,
-  latestRemoteNightlyVersion?: Version
+  localVersions: LocalBitVersions,
+  remoteVersions: RemoteBitVersions
 ): string | undefined {
+  const { currentVersion, latestInstalledVersion } = localVersions;
+  const { latestRemoteNightlyVersion, latestRemoteStableVersion } = remoteVersions;
+
   if (!currentVersion) {
     return undefined;
   }
@@ -177,8 +176,8 @@ function getNewerBitAvailableOutput(
     return undefined;
   }
 
-  const moreRecentLocalVersionOutput = latestInstalledVersion && (semver.gt(latestInstalledVersion, currentVersion)) 
-    ? `\nNOTE: you have a more recent version of bit (${latestInstalledVersion}) installed on your machine - run ${chalk.cyan(`bvm use ${latestInstalledVersion}`)} to use your latest installed version`
+  const moreRecentLocalVersionOutput = latestInstalledVersion && (semver.gt(latestInstalledVersion.version, currentVersion.version)) 
+    ? `\nNOTE: you have a more recent version of bit (${latestInstalledVersion.version}) installed - run ${chalk.cyan(`bvm use ${latestInstalledVersion.version}`)} to use your latest installed version`
     : undefined;
 
   function newVersionAvailableText(versionToCheck?: Version){
@@ -189,7 +188,7 @@ function getNewerBitAvailableOutput(
       `bvm install ${version}`
       : "bvm upgrade"
     
-    if ((version && semver.gt(version, currentVersion || "0.0.0")))
+    if ((version && semver.gt(version, currentVersion!.version)))
     {
       return `${chalk.greenBright("newer")} ${releaseType?.toString() ?? ""} version (${version}) of ${chalk.cyan("bit")} `+
            `is available, upgrade ${chalk.cyan("bit")} to the latest version by running "${chalk.cyan(commandToRun)}"\n`;

--- a/teambit.bvm/commands/version/version.ts
+++ b/teambit.bvm/commands/version/version.ts
@@ -177,7 +177,7 @@ function getNewerBitAvailableOutput(
   }
 
   const moreRecentLocalVersionOutput = latestInstalledVersion && (semver.gt(latestInstalledVersion.version, currentVersion.version)) 
-    ? `\nNOTE: you have a more recent version of bit (${latestInstalledVersion.version}) installed - run ${chalk.cyan(`bvm use ${latestInstalledVersion.version}`)} to use your latest installed version`
+    ? `\nNOTE: you have a more recent version of bit (${latestInstalledVersion.version}) installed - run "${chalk.cyan(`bvm use ${latestInstalledVersion.version}`)}" to use your latest installed version`
     : undefined;
 
   function newVersionAvailableText(versionToCheck?: Version){
@@ -190,7 +190,7 @@ function getNewerBitAvailableOutput(
     
     if ((version && semver.gt(version, currentVersion!.version)))
     {
-      return `${chalk.greenBright("newer")} ${releaseType?.toString() ?? ""} version (${version}) of ${chalk.cyan("bit")} `+
+      return `${chalk.greenBright("new")} ${releaseType?.toString() ?? ""} version (${version}) of ${chalk.cyan("bit")} `+
            `is available, upgrade ${chalk.cyan("bit")} to the latest version by running "${chalk.cyan(commandToRun)}"\n`;
     }      
   }

--- a/teambit.bvm/list/gcp/gcp-version.ts
+++ b/teambit.bvm/list/gcp/gcp-version.ts
@@ -1,4 +1,5 @@
 import { RemoteVersion } from '../version';
+import { ReleaseType } from './gcp-list';
 
 export class GcpVersion {
   constructor(
@@ -8,7 +9,8 @@ export class GcpVersion {
     private md5hash: string,
     private timeCreated: string,
     private metadata: { [key: string]: string },
-    private protocol = 'https'
+    private protocol = 'https',
+    private releaseType?: ReleaseType
   ) { }
 
   get url() {
@@ -16,13 +18,13 @@ export class GcpVersion {
   }
 
   /** is version is stable version  */
-  get stable() {
-    if (this.metadata?.stable) return true;
-    return false;
+  get calculatedReleaseType() {
+    const type = this.metadata?.stable ? ReleaseType.STABLE : this.releaseType ?? ReleaseType.NIGHTLY; // TODO @giladshoam what's the metadata doing here? Can we get rid of it and just use releaseType when storing the version?
+    return type;
   }
 
   toRemoteVersion(): RemoteVersion {
-    return new RemoteVersion(this.version, this.url, this.md5hash, this.timeCreated, this.stable);
+    return new RemoteVersion(this.version, this.url, this.md5hash, this.timeCreated, this.calculatedReleaseType);
   }
 
   toObject() {

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -39,7 +39,7 @@ export async function listLocal(): Promise<LocalVersionList> {
   if (!exists) return new LocalVersionList([]);
   const dirEntries = await fs.readdir(versionsDir, { withFileTypes: true });
   const gcpList = getGcpList();
-  const versionsMap = await (await gcpList.list()).toMap();
+  const versionsMap = (await gcpList.list()).toMap();
   const versions = dirEntries
     .filter((dirent) => {
       return (dirent.isDirectory() || dirent.isSymbolicLink()) && semver.valid(dirent.name);

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -38,6 +38,8 @@ export async function listLocal(): Promise<LocalVersionList> {
   const exists = await fs.pathExists(versionsDir);
   if (!exists) return new LocalVersionList([]);
   const dirEntries = await fs.readdir(versionsDir, { withFileTypes: true });
+  const gcpList = getGcpList();
+  const versionsMap = await (await gcpList.list()).toMap();
   const versions = dirEntries
     .filter((dirent) => {
       return (dirent.isDirectory() || dirent.isSymbolicLink()) && semver.valid(dirent.name);
@@ -45,7 +47,8 @@ export async function listLocal(): Promise<LocalVersionList> {
     .map((dirent) => {
       const version = dirent.name;
       const { versionDir } = config.getSpecificVersionDir(version);
-      const localVersion = new LocalVersion(version, versionDir);
+      const releaseType = versionsMap.get(version);
+      const localVersion = new LocalVersion(version, versionDir, releaseType);
       return localVersion;
     });
   return new LocalVersionList(versions);

--- a/teambit.bvm/list/version-list/remote-version-list.ts
+++ b/teambit.bvm/list/version-list/remote-version-list.ts
@@ -1,3 +1,4 @@
+import { ReleaseType } from '../gcp';
 import { RemoteVersion } from '../version';
 import { VersionList } from './version-list';
 
@@ -6,10 +7,10 @@ export class RemoteVersionList extends VersionList {
     super(entries);
   }
 
-  stableVersions() {
+  versionsByReleaseType(releaseTypes: ReleaseType[]) {
     const sorted = VersionList.sortList<RemoteVersion>(this.entries);
-    const stableVersions = sorted.filter((version) => version.stable);
-    return new RemoteVersionList(stableVersions);
+    const requestedVersions = sorted.filter((version) => releaseTypes.some(rt => rt as ReleaseType === version.releaseType as ReleaseType));
+    return new RemoteVersionList(requestedVersions);
   }
 
   slice(limit: number = 20, offset: number = 0): RemoteVersionList {

--- a/teambit.bvm/list/version-list/version-list.ts
+++ b/teambit.bvm/list/version-list/version-list.ts
@@ -18,6 +18,10 @@ export class VersionList {
     return this.entries.map(entry => entry.version);
   }
 
+  toMap(){
+    return new Map(this.entries.map(e => [e.version, e.releasetype]));
+  }
+
   sortBySemver(order: 'asc' | 'desc' = 'desc'): VersionList {
     let sorted = VersionList.sortList(this.entries, order);   
     return new VersionList(sorted)

--- a/teambit.bvm/list/version-list/version-list.ts
+++ b/teambit.bvm/list/version-list/version-list.ts
@@ -19,7 +19,7 @@ export class VersionList {
   }
 
   toMap(){
-    return new Map(this.entries.map(e => [e.version, e.releasetype]));
+    return new Map(this.entries.map(e => [e.version, e.releaseType]));
   }
 
   sortBySemver(order: 'asc' | 'desc' = 'desc'): VersionList {

--- a/teambit.bvm/list/version/local-version.ts
+++ b/teambit.bvm/list/version/local-version.ts
@@ -1,5 +1,5 @@
 import { ReleaseType } from '../gcp';
-import {Version} from './version';
+import { Version } from './version';
 
 export class LocalVersion extends Version {
   constructor(public version: string, public path: string, releaseType?: ReleaseType){

--- a/teambit.bvm/list/version/local-version.ts
+++ b/teambit.bvm/list/version/local-version.ts
@@ -1,7 +1,8 @@
+import { ReleaseType } from '../gcp';
 import {Version} from './version';
 
 export class LocalVersion extends Version {
-  constructor(public version: string, public path: string){
-    super(version);
+  constructor(public version: string, public path: string, releaseType?: ReleaseType){
+    super(version, releaseType);
   }
 }

--- a/teambit.bvm/list/version/remote-version.ts
+++ b/teambit.bvm/list/version/remote-version.ts
@@ -1,7 +1,8 @@
+import { ReleaseType } from '../gcp';
 import { Version } from './version';
 
 export class RemoteVersion extends Version {
-  constructor(public version: string, public url: string, public md5Hash: string, public released: string, public stable: boolean) {
-    super(version);
+  constructor(public version: string, public url: string, public md5Hash: string, public released: string, releaseType?: ReleaseType) {
+    super(version, releaseType);
   }
 }

--- a/teambit.bvm/list/version/version.ts
+++ b/teambit.bvm/list/version/version.ts
@@ -3,6 +3,6 @@ import { ReleaseType } from "../gcp";
 export class Version {
   constructor(
     public version: string,
-    public releasetype?: ReleaseType
+    public releaseType?: ReleaseType
   ){}
 }

--- a/teambit.bvm/list/version/version.ts
+++ b/teambit.bvm/list/version/version.ts
@@ -1,3 +1,8 @@
+import { ReleaseType } from "../gcp";
+
 export class Version {
-  constructor(public version: string){}
+  constructor(
+    public version: string,
+    public releasetype?: ReleaseType
+  ){}
 }


### PR DESCRIPTION
- add latest nightly release to `bvm version` printout (only when nightly is set as the release type)
- added version type for latest installed and currently used versions in the above printout