### PR TITLE
extract method improvements

### DIFF
--- a/teambit.bvm/config/config.ts
+++ b/teambit.bvm/config/config.ts
@@ -23,6 +23,7 @@ const CONFIG_KEY_NAME = 'global';
 
 export const CFG_BVM_DIR = 'BVM_DIR';
 export const CFG_RELEASE_TYPE = 'RELEASE_TYPE';
+export const CFG_EXTRACT_METHOD = 'EXTRACT_METHOD';
 export const CFG_PROXY = 'proxy';
 export const CFG_HTTPS_PROXY = 'https_proxy';
 export const CFG_PROXY_CA = 'proxy.ca';
@@ -48,6 +49,7 @@ export const KNOWN_KEYS = [
   CFG_BVM_DIR,
   "DEFAULT_LINK",
   CFG_RELEASE_TYPE,
+  CFG_EXTRACT_METHOD,
   CFG_GCP_ACCESS_KEY,
   CFG_GCP_SECRET_KEY,
   CFG_PROXY,
@@ -198,6 +200,10 @@ export class Config {
 
   getDefaultLinkName(): string {
     return this.store.get('DEFAULT_LINK');
+  }
+
+  getExtractMethod(): string {
+    return this.store.get(CFG_EXTRACT_METHOD);
   }
 
   getBitVersionsDir(): string {

--- a/teambit.bvm/install/install.ts
+++ b/teambit.bvm/install/install.ts
@@ -150,7 +150,7 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
   }
 }
 
-function getExtractMethod(extractMethod?: ExtractMethod, osName? :string): ExtractMethod {
+function getExtractMethod(extractMethod?: ExtractMethod, osName?: string): ExtractMethod {
   const validExtractMethods: ExtractMethod[] = ['default', 'child-process'];
   const extractMethodOrFromConfig = extractMethod || getConfig().getExtractMethod() as ExtractMethod;
 

--- a/teambit.bvm/install/install.ts
+++ b/teambit.bvm/install/install.ts
@@ -1,4 +1,5 @@
 import execa from 'execa';
+import os from 'os';
 import fs, { MoveOptions } from 'fs-extra';
 import path from 'path';
 import semver from 'semver';
@@ -11,7 +12,7 @@ import { timeFormat } from '@teambit/toolbox.time.time-format';
 import { Config } from '@teambit/bvm.config';
 import { BvmError } from '@teambit/bvm.error';
 import {linkOne, PathExtenderReport} from '@teambit/bvm.link';
-import { GcpListOptions, listRemote } from '@teambit/bvm.list';
+import { GcpListOptions, getOsType, listRemote } from '@teambit/bvm.list';
 import { FsTarVersion } from '@teambit/bvm.fs-tar-version';
 
 export type InstallOpts = GcpListOptions & {
@@ -19,9 +20,11 @@ export type InstallOpts = GcpListOptions & {
   override?: boolean,
   replace?: boolean,
   file?: string,
-  extractMethod?: string,
+  extractMethod?: ExtractMethod,
   useSystemNode?: boolean
 }
+
+export type ExtractMethod = 'default' | 'child-process';
 
 export type InstallResults = {
   installedVersion: string,
@@ -36,6 +39,12 @@ export type InstallResults = {
 const defaultOpts = {
   override: false,
   replace: false
+}
+
+const OS_DEFAULT_EXTRACT_METHOD = {
+  'linux': 'default',
+  'win': 'child-process',
+  'darwin': 'default'
 }
 
 const loader = ora();
@@ -94,10 +103,11 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
 
   if (fsTarVersion.path) {
     const tarFile = fsTarVersion.path;
-    if (!opts.extractMethod || opts.extractMethod === 'default') {
+    const extractMethod = getExtractMethod(opts.extractMethod, opts.os);
+    if (!extractMethod || extractMethod === 'default') {
       await extractWithLoader(fsTarVersion.path, fsTarVersion.version);
     } else {
-      const extractMsg = `extracting version ${fsTarVersion.version} using ${opts.extractMethod} method`;
+      const extractMsg = `extracting version ${fsTarVersion.version} using ${extractMethod} method`;
       loader.start(extractMsg);
       const extractStartTime = Date.now();
       try {
@@ -138,6 +148,17 @@ export async function installVersion(version: string, opts: InstallOpts = defaul
     warnings: replacedCurrentResult.warnings,
     versionPath: versionDir
   }
+}
+
+function getExtractMethod(extractMethod?: ExtractMethod, osName? :string): ExtractMethod {
+  const validExtractMethods: ExtractMethod[] = ['default', 'child-process'];
+  const extractMethodOrFromConfig = extractMethod || getConfig().getExtractMethod() as ExtractMethod;
+
+  if (extractMethodOrFromConfig && validExtractMethods.includes(extractMethodOrFromConfig)) {
+    return extractMethodOrFromConfig;
+  }
+  const osType = getOsType(osName);
+  return (OS_DEFAULT_EXTRACT_METHOD[osType] || 'default') as ExtractMethod;
 }
 
 /*

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -48,7 +48,7 @@ export function getGcpList(options?: GcpListOptions): GcpList {
 }
 
 export function getOsType(osName?: string): OS_TYPE {
-  const osType = osName ? OS_TYPES[osName.toLowerCase()] : OS_TYPES[os.type().toLowerCase()];
+  const osType = OS_TYPES[(osName || os.type()).toLowerCase()];
   return osType
 }
 

--- a/teambit.bvm/list/list.ts
+++ b/teambit.bvm/list/list.ts
@@ -15,6 +15,8 @@ export type ListOptions = GcpListOptions & {
   limit?: number;
 };
 
+type OS_TYPE = 'win' | 'linux' | 'darwin';
+
 export const supportedPlatforms = {
   'linux': ['x64'],
   'win': ['x64'],
@@ -35,7 +37,7 @@ const config = Config.load();
 export function getGcpList(options?: GcpListOptions): GcpList {
   const releaseType = options?.releaseType ?? config.getReleaseType();
   const {accessKey, secretKey} = config.gcpConfig();
-  const osType = options?.os ? OS_TYPES[options?.os.toLowerCase()] : OS_TYPES[os.type().toLowerCase()];
+  const osType = getOsType(options?.os);
   const arch = options?.arch ?? process.arch;
   const archWithFallback = validatePlatform(osType, arch);
   const gcpList = GcpList.create(releaseType, osType, archWithFallback, {
@@ -45,6 +47,10 @@ export function getGcpList(options?: GcpListOptions): GcpList {
   return gcpList;
 }
 
+export function getOsType(osName?: string): OS_TYPE {
+  const osType = osName ? OS_TYPES[osName.toLowerCase()] : OS_TYPES[os.type().toLowerCase()];
+  return osType
+}
 
 /**
  * It throws an error if the given platform is not supported


### PR DESCRIPTION
- set child-process as the default extract method for windows
- allow globally configure the default extract method (config name is `EXTRACT_METHOD`)
usage:
`bvm config set EXTRACT_METHOD "default | child-process"`
