### PR TITLE
perf, remove fs-extra, chalk and semver usages from teambit.bvm/config

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -82,7 +82,7 @@
     "config": {
         "name": "config",
         "scope": "teambit.bvm",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "mainFile": "index.ts",
         "rootDir": "teambit.bvm/config"
     },

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -83,7 +83,7 @@
         "tar": "7.4.3",
         "tar-fs": "2.1.1",
         "tty-table": "4.1.3",
-        "user-home": "2.0.0",
+        "user-home": "3.0.0",
         "yargs": "17.0.1"
       },
       "peerDependencies": {}


### PR DESCRIPTION
It helps reducing the files loaded during bit's bootstrap by 75.