### PR TITLE
fix: delete previous version after upgrade

### DIFF
--- a/teambit.bvm/commands/upgrade/upgrade.ts
+++ b/teambit.bvm/commands/upgrade/upgrade.ts
@@ -1,5 +1,6 @@
 import type { CommandModule, Argv } from "yargs";
 import { installVersion, InstallResults, InstallationMethods, InstallationMethod } from "@teambit/bvm.install";
+import { removeVersions } from "@teambit/bvm.remove";
 import chalk from "chalk";
 import {
   getBvmLocalVersion,
@@ -97,6 +98,9 @@ export class UpgradeCmd implements CommandModule {
       method: args.method,
       lockfilePath: args.lockfilePath,
     });
+    if (upgradeResults.previousCurrentVersion && upgradeResults.previousCurrentVersion !== upgradeResults.installedVersion) {
+      await removeVersions([upgradeResults.previousCurrentVersion]);
+    }
     printOutput(upgradeResults);
   }
 }


### PR DESCRIPTION
## Summary
- The upgrade command described itself as deleting the previous installed version, but never actually did
- After a successful upgrade, now calls `removeVersions()` on the previous version (when it differs from the newly installed one)

## Test plan
- [ ] Run `bvm upgrade` when a newer version is available and verify the old version directory is removed from `~/.bvm/versions/`
- [ ] Run `bvm upgrade` when already on latest and verify nothing is removed